### PR TITLE
Add new command 'help'

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -13,6 +13,10 @@ switch (command) {
     generate()
     break
 
+  case 'help':
+    console.log('Usage: startup-cli generate')
+    break
+
   default:
     console.log('Invalid command syntax. Type \'help\' to see correct syntax.')
 


### PR DESCRIPTION
The 'invalid command syntax' message implies the existence of a 'help' command, so I made it.